### PR TITLE
Prepend the script to PATH for tests

### DIFF
--- a/fixtures/hello-world/test.dockerfile
+++ b/fixtures/hello-world/test.dockerfile
@@ -1,7 +1,4 @@
 #!/usr/bin/env dockerfile-shebang
-# NOTE: This test is not actually executed using the shebang since it
-# cannot use relative paths. It is only included for demonstrating
-# normal usage.
 
 FROM alpine:latest
 ENTRYPOINT ["echo"]

--- a/test.sh
+++ b/test.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
+# https://stackoverflow.com/a/4774063/132047
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
 success=0
 failures=0
-for d in fixtures/*/; do
+for d in "$SCRIPTPATH"/fixtures/*/; do
   echo -n "$(basename "$d")… "
 
-  diff=$(diff -U 0 "$d""expected.txt" <(./dockerfile-shebang "$d""test.dockerfile" $(< "$d""args.txt")))
+  diff=$(diff -U 0 "$d""expected.txt" <(PATH="$SCRIPTPATH":$PATH "$d""test.dockerfile" $(< "$d""args.txt")))
 
   if [[ $? == 0 ]]; then
     echo "✅"


### PR DESCRIPTION
This allows execution using actual shebangs rather than as a 'normal' binary.